### PR TITLE
debugger_posix.cc: execinfo.h is glibc/uclibc specific

### DIFF
--- a/src/base/debug/debugger_posix.cc
+++ b/src/base/debug/debugger_posix.cc
@@ -17,7 +17,7 @@
 #include <string>
 #include <vector>
 
-#if !defined(OS_ANDROID) && !defined(OS_NACL)
+#if !defined(OS_ANDROID) && !defined(OS_NACL) && defined(__GLIBC__)
 #include <execinfo.h>
 #endif
 


### PR DESCRIPTION
uclibc also defines __GLIBC__ so it will work for both
however musl does not have this .h file and it will work
there too.

Signed-off-by: Khem Raj <raj.khem@gmail.com>